### PR TITLE
add: eslintとprettierのrulesにセミコロン省略設定

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,28 +4,33 @@ module.exports = {
     browser: true
   },
   extends: [
-    'plugin:vue/essential',
-    'eslint:recommended',
-    'plugin:prettier/recommended'
+    "plugin:vue/essential",
+    "eslint:recommended",
+    "plugin:prettier/recommended"
   ],
   plugins: [
-    'vue',
-    'prettier'
+    "vue",
+    "prettier"
   ],
   rules: {
+    "prettier/prettier": [
+      "error", {
+        "semi": false
+      }
+    ],  
     //[off, 0]はルールを無効、[warn, 1]はルール違反時に警告を表示する、[error, 2]はルール違反時にエラーを表示する
     //ジェネレーター関数の中の * の周りのスペースを強制する
-    'generator-star-spacing': 'off',
+    "generator-star-spacing": "off",
     //debuggerの使用をしないよう強制する
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
     //アロー関数の引数でequire括弧、アロー関数の括弧の一貫した使用を強制する
-    'arrow-parens': 0,
+    "arrow-parens": 0,
     //ブロックスコープ内では１度の宣言で必要なショートバンドで記載する
-    'one-var': 0,
+    "one-var": 0,
     //debuggerの使用をしないよう強制する
-    'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
+    "no-debugger": process.env.NODE_ENV === "production" ? 2 : 0,
     //インデントを2つに揃えることを強制する、HTMLのように4つに揃えたい時は ["error", 2]と記載する
     "vue/html-indent": ["error", 2],
-    "no-undef": 'off'
+    "no-undef": "off",
   }
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,17 +1,17 @@
-module.exports = function(api){
-  api.cache(true);
+module.exports = function(api) {
+  api.cache(true)
 
   const presets = [
     [
       //プリセットに@babel/preset-env を指定する
-      '@babel/preset-env',
+      "@babel/preset-env",
       {
         //サポートするブラウザ、この設定に応じて必要なpolyfillのみがimportされる
-        targets:{
-          ie: '11'
+        targets: {
+          ie: "11"
         },
         //必要なpolyfillのみをimportさせたい場合、'usage'を指定する
-        useBuiltIns: 'usage',
+        useBuiltIns: "usage",
         //polyfillを利用する core-js のバージョンを指定する(指定しないとバージョン２が利用され警告が出力される)
         corejs: 3,
         //Stage 4 未満のプロボーザルのpolyfillもimportされる
@@ -21,8 +21,8 @@ module.exports = function(api){
         debug: true
       }
     ]
-  ];
-  return{
+  ]
+  return {
     presets
-  };
-};
+  }
+}

--- a/src/pages/login/index.js
+++ b/src/pages/login/index.js
@@ -1,10 +1,10 @@
-import Login from "components/Pages/Login.vue";
+import Login from "components/Pages/Login.vue"
 
-Vue.config.productionTip = false;
+Vue.config.productionTip = false
 
 /* eslint-disable no-new */
 new Vue({
   el: "#component",
   template: "<Login/>",
   components: { Login }
-});
+})

--- a/src/pages/top/index.js
+++ b/src/pages/top/index.js
@@ -1,10 +1,10 @@
-import Top from "components/Pages/Top.vue";
+import Top from "components/Pages/Top.vue"
 
-Vue.config.productionTip = false;
+Vue.config.productionTip = false
 
 /* eslint-disable no-new */
 new Vue({
   el: "#component",
   template: "<Top/>",
   components: { Top }
-});
+})

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,21 +1,20 @@
-const path = require('path')
-const glob = require('glob')
-const webpack = require('webpack')
-const VueLoaderPlugin = require('vue-loader/lib/plugin')
-const HtmlWebpackPlugin = require('html-webpack-plugin')
-
+const path = require("path")
+const glob = require("glob")
+const webpack = require("webpack")
+const VueLoaderPlugin = require("vue-loader/lib/plugin")
+const HtmlWebpackPlugin = require("html-webpack-plugin")
 const ROOT = path.resolve(__dirname)
-const DIST = path.resolve(ROOT, './dist')
-const SRC_ROOT = path.resolve(ROOT, './src')
-const PAGES_ROOT = path.resolve(SRC_ROOT, './pages')
+const DIST = path.resolve(ROOT, "./dist")
+const SRC_ROOT = path.resolve(ROOT, "./src")
+const PAGES_ROOT = path.resolve(SRC_ROOT, "./pages")
 
 const webpackConfig = {
   entry: {}, // 動的に生成
 
   output: {
-    path: path.resolve('dist'),
+    path: path.resolve("dist"),
     publicPath: DIST,
-    filename: '[name]'
+    filename: "[name]"
   },
 
   devServer: {
@@ -28,55 +27,64 @@ const webpackConfig = {
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        use: [{
-          loader: 'babel-loader',
-          options: {
-            presets: ['@babel/preset-env']
+        use: [
+          {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env"]
+            }
           }
-        }]
+        ]
       },
-      { test: /\.vue$/, loader: 'vue-loader'},
-      { test: /\.css$/, use: [ 'vue-style-loader', 'css-loader' ]}
+      { test: /\.vue$/, loader: "vue-loader" },
+      { test: /\.css$/, use: ["vue-style-loader", "css-loader"] }
     ]
   },
 
   resolve: {
     alias: {
-      components: path.resolve(SRC_ROOT, './components'),
-      pages: path.resolve(SRC_ROOT, './pages')
+      components: path.resolve(SRC_ROOT, "./components"),
+      pages: path.resolve(SRC_ROOT, "./pages")
     }
   },
 
   plugins: [
     new VueLoaderPlugin(),
     new webpack.ProvidePlugin({
-      Vue: ['vue/dist/vue.esm.js', 'default']
-    }),
+      Vue: ["vue/dist/vue.esm.js", "default"]
+    })
   ],
 
   optimization: {
     splitChunks: {
-      name: 'vendor.js',
-      chunks: 'initial'
+      name: "vendor.js",
+      chunks: "initial"
     }
   }
 }
 
-glob.sync('**/**/*.js', {
-  cwd: PAGES_ROOT,
-}).forEach(jsPathName => {
-  const dirName = jsPathName.split("/")[0]
-  const jsFileName = `${dirName}.js`
-  const htmlFileName = `${dirName}.html`
-  webpackConfig.entry[jsFileName] = path.resolve(PAGES_ROOT, `${dirName}/index`)
+glob
+  .sync("**/**/*.js", {
+    cwd: PAGES_ROOT
+  })
+  .forEach(jsPathName => {
+    const dirName = jsPathName.split("/")[0]
+    const jsFileName = `${dirName}.js`
+    const htmlFileName = `${dirName}.html`
+    webpackConfig.entry[jsFileName] = path.resolve(
+      PAGES_ROOT,
+      `${dirName}/index`
+    )
 
-  webpackConfig.plugins.push(new HtmlWebpackPlugin({
-    template: path.resolve(PAGES_ROOT, `${dirName}/index.html`),
-    filename: htmlFileName,
-    inject: 'body',
-    includeSiblingChunks: true,
-    chunks: ['vendor.js', jsFileName]
-  }))
-})
+    webpackConfig.plugins.push(
+      new HtmlWebpackPlugin({
+        template: path.resolve(PAGES_ROOT, `${dirName}/index.html`),
+        filename: htmlFileName,
+        inject: "body",
+        includeSiblingChunks: true,
+        chunks: ["vendor.js", jsFileName]
+      })
+    )
+  })
 
 module.exports = webpackConfig


### PR DESCRIPTION
## 概要

- eslintのrecommendedのデフォルト設定で、セミコロンの省略がASIで対応できない場合のみエラーを表示する設定
- prettierはデフォルト設定で、セミコロン必須になっているので、eslintrc.jsファイル内のrulesで、セミコロン省略の設定を追加
- precommit時にセミコロンがある部分は、自動でセミコロンを削除しコード整形が行われるよう設定


## 備考

- 末尾コンマはデフォルトで、入っているとエラーになる
- 文字列ダブルクォートも同じくデフォルトとなっており、シングルクォートでエラーになる
