### PR TITLE
fix: webpack-dev-server の参照先を適切に修正

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,8 +13,7 @@ const webpackConfig = {
   entry: {}, // 動的に生成
 
   output: {
-    path: path.resolve('dist'),
-    publicPath: DIST,
+    path: DIST,
     filename: '[name]'
   },
 


### PR DESCRIPTION
## 概要
