### PR TITLE
Babel 設定更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -718,16 +718,6 @@
         "regexpu-core": "^4.5.4"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
-      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
     "@babel/preset-env": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.0.tgz",
@@ -2474,10 +2464,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
-      "dev": true
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
+      "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
     },
     "core-js-compat": {
       "version": "3.1.4",
@@ -8121,8 +8110,7 @@
     "regenerator-runtime": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-      "dev": true
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
     "regenerator-transform": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "@babel/cli": "^7.5.0",
     "@babel/core": "^7.4.5",
-    "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.4.5",
     "babel-loader": "^8.0.6",
     "css-loader": "^3.0.0",
@@ -53,6 +52,8 @@
     "webpack-dev-server": "^3.7.2"
   },
   "dependencies": {
+    "core-js": "^3.1.4",
+    "regenerator-runtime": "^0.13.2",
     "vue": "^2.6.10"
   }
 }

--- a/src/pages/test/index.html
+++ b/src/pages/test/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>初期ページ</title>
+  </head>
+  <body>
+    <div id="component"></div>
+    <!-- built files will be auto injected -->
+  </body>
+</html>

--- a/src/pages/test/index.js
+++ b/src/pages/test/index.js
@@ -1,0 +1,15 @@
+import "core-js/shim"
+import "regenerator-runtime/runtime"
+
+import add from "utils/testcodes/add"
+
+console.info(add(2, 3))
+console.info(["hoge", "fuga", "piyo"].includes("piyo"))
+
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+async () => {
+  console.log("start")
+  await wait(2000)
+  console.log("end")
+}

--- a/src/utils/testcodes/add.js
+++ b/src/utils/testcodes/add.js
@@ -1,0 +1,3 @@
+export default function(a, b) {
+  return a + b
+}


### PR DESCRIPTION
## 概要

- Babel v7.5 では `@babel/polyfill` が非推奨となったため、使用しないように対応
    - https://aloerina01.github.io/blog/2019-06-21-1
    - サンプルコードを追加
